### PR TITLE
Fixed output path when path extration was enabled

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -98,7 +98,7 @@ module.exports = Compiler = (function() {
 
             var outputPathExtracted = atom.config.get('sass-compiler.outputPathExtracted');
             var inputFullPath       = extracted_path + scss_catalog + '/' + fileName + '.scss';
-            var outputFullPath      = extracted_path + fileName + '.css';
+            var outputFullPath      = extracted_path + outputPathExtracted + '/' + fileName + '.css';
         }
 
         // @TODO source-maps not working in cli // + ' --source-map ' + sourceMap


### PR DESCRIPTION
This fixed a issue where the compiler was ignoring the extraction path used in the settings, always exporting the resulting css to the "extracted path" it's self.

It seemed to me that that code was supost to be the way it is now, sience the variable "outputPathExtracted" was not being used at all.
