### PR TITLE
Added source map support and a sourcemap checkbox in the config page.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Works only in Windows.
 ## Modes
 Available two compiling file detection modes:
 * Base path is editor project.
-* Tries to extract current path from editable file. It will check if **inputPath** value are in editable file path, and it will be reference point for compiling `Scss` file. Aslo it could be specified based on reference point with **outputPathExtracted**.
+* Tries to extract current path from editable file. It will check if **inputPath** value are in editable file path, and it will be reference point for compiling `Scss` file. Also it could be specified based on reference point with **outputPathExtracted**.
 
 ## Settings
 | Parameter           	| Description                                    	|
@@ -18,8 +18,10 @@ Available two compiling file detection modes:
 | outputPath          	| This specifies where the *CSS* will be saved. ( Path relative to your project ).                                   	|
 | fileName            	| *Scss* type file name, to be parent of all @include.                                                               	|
 | outputStyle         	| `String` to determine how the final *CSS* should be rendered. Its value should be one of `nested` or `compressed`. 	|
-| successMsg          	| Eneable/disable success message.                                                                                   	|
-| extractPath         	| Eneable/disable - Get path from file. ( package tries to extract current path based on editable file and sets reference point ).                              	|
+| successMsg          	| Enable/disable success message.                                                                                   	|
+| extractPath         	| Enable/disable - Get path from file. ( package tries to extract current path based on editable file and sets reference point ).                   
+| sourceMap          	| Enable/disable auto-generated source map ( generated.css.map ).                                                     	|
+|
 | inputPathExtracted  	| Specifies where your *Scss* files are stored. ( Relative to extracted reference point ).                            	|
 | outputPathExtracted 	| Specifies where the *CSS* will be saved. ( Relative to extracted reference point ).                                 	|
 

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -7,14 +7,14 @@ module.exports = Compiler = (function() {
         this.project_path   = atom.project.getPaths()[0];
 
         var saveAction = function( e ){
-            
+
             if ( !currentView['sass-compiler-view-modified'] ) {
-                
+
                 return false;
             }
-            
+
             currentView['sass-compiler-view-modified'] = false;
-            
+
             if ( _this.extension == 'scss' ) {
 
                 _this.compile( _this.filePath );
@@ -76,13 +76,12 @@ module.exports = Compiler = (function() {
         var inputPath       = atom.config.get('sass-compiler.inputPath');
         var outputPath      = atom.config.get('sass-compiler.outputPath');
         var fileName        = atom.config.get('sass-compiler.fileName');
+        var sourceMap        = atom.config.get('sass-compiler.sourceMap');
 
-        if ( !atom.config.get('sass-compiler.extractPath') ) {
+        var inputFullPath   = this.project_path + '/' + inputPath + '/' + fileName + '.scss';
+        var outputFullPath  = this.project_path + '/' + outputPath + '/' + fileName + '.css';
 
-
-            var inputFullPath   = this.project_path + '/' + inputPath + '/' + fileName + '.scss';
-            var outputFullPath  = this.project_path + '/' + outputPath + '/' + fileName + '.css';
-        } else {
+        if (atom.config.get('sass-compiler.extractPath') ) {
 
             var path_array          = filePath.split( '\\' );
             var extracted_path      = '';
@@ -97,16 +96,21 @@ module.exports = Compiler = (function() {
             }
 
             var outputPathExtracted = atom.config.get('sass-compiler.outputPathExtracted');
-            var inputFullPath       = extracted_path + scss_catalog + '/' + fileName + '.scss';
-            var outputFullPath      = extracted_path + outputPathExtracted + '/' + fileName + '.css';
+            inputFullPath       = extracted_path + scss_catalog + '/' + fileName + '.scss';
+            outputFullPath      = extracted_path + outputPathExtracted + '/' + fileName + '.css';
         }
 
-        // @TODO source-maps not working in cli // + ' --source-map ' + sourceMap
-        var execString = 'node-sass --output-style ' + outputStyle + ' ' + inputFullPath + ' ' + outputFullPath;
+        var execString = 'node-sass --output-style ' + outputStyle +
+            ' ' + inputFullPath + ' ' + outputFullPath;
 
+        if ( sourceMap ) {
+            // adds the source-map cli param only if set to true.
+            // Prevents problem if libsass cli fails when the source-map param is set.
+            execString += ' --source-map ' + sourceMap;
+        }
         exec( execString, function (error, stdout, stderr) {
 
-            if ( error != null ) {
+            if ( error !== null ) {
 
                 atom.notifications.addError( 'Error while compiling:',{
                     detail: error.message,
@@ -120,7 +124,7 @@ module.exports = Compiler = (function() {
                 }
             }
         });
-    }
+    };
 
     return Compiler;
 })();

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -1,21 +1,25 @@
 module.exports = Compiler = (function() {
 
+    var _debug          = {};
+
     function Compiler() {
 
         var _this           = this;
         var currentView     = atom.workspace.getActiveTextEditor();
         this.project_path   = atom.project.getPaths()[0];
 
+
         var saveAction = function( e ){
 
-            if ( !currentView['sass-compiler-view-modified'] ) {
-
+            /* if ( !currentView['sass-compiler-view-modified'] ) {
+                console.log(_this.currentView);
                 return false;
-            }
+            } */
 
             currentView['sass-compiler-view-modified'] = false;
 
             if ( _this.extension == 'scss' ) {
+
 
                 _this.compile( _this.filePath );
             }
@@ -72,16 +76,15 @@ module.exports = Compiler = (function() {
         var exec            = require('child_process').exec;
 
         // Settings
-        var outputStyle     = atom.config.get('sass-compiler.outputStyle');
-        var inputPath       = atom.config.get('sass-compiler.inputPath');
-        var outputPath      = atom.config.get('sass-compiler.outputPath');
-        var fileName        = atom.config.get('sass-compiler.fileName');
         var sourceMap        = atom.config.get('sass-compiler.sourceMap');
+        var inputFilePath    = atom.config.get('sass-compiler.inputFilePath');
+        var outputFilePath   = atom.config.get('sass-compiler.outputFilePath');
+        var outputStyle     = atom.config.get('sass-compiler.outputStyle'); 
 
-        var inputFullPath   = this.project_path + '/' + inputPath + '/' + fileName + '.scss';
-        var outputFullPath  = this.project_path + '/' + outputPath + '/' + fileName + '.css';
+        var inputFullPath   = this.project_path + '/' + inputFilePath;
+        var outputFullPath  = this.project_path + '/' + outputFilePath;
 
-        if (atom.config.get('sass-compiler.extractPath') ) {
+        /* if (atom.config.get('sass-compiler.extractPath') ) {
 
             var path_array          = filePath.split( '\\' );
             var extracted_path      = '';
@@ -98,16 +101,17 @@ module.exports = Compiler = (function() {
             var outputPathExtracted = atom.config.get('sass-compiler.outputPathExtracted');
             inputFullPath       = extracted_path + scss_catalog + '/' + fileName + '.scss';
             outputFullPath      = extracted_path + outputPathExtracted + '/' + fileName + '.css';
-        }
+        } */
 
-        var execString = 'node-sass --output-style ' + outputStyle +
-            ' ' + inputFullPath + ' ' + outputFullPath;
+        var execString = 'node-sass --output-style ' + outputStyle + ' ' + inputFullPath + ' ' + outputFullPath;
+        console.log(execString);
 
         if ( sourceMap ) {
             // adds the source-map cli param only if set to true.
             // Prevents problem if libsass cli fails when the source-map param is set.
             execString += ' --source-map ' + sourceMap;
         }
+
         exec( execString, function (error, stdout, stderr) {
 
             if ( error !== null ) {
@@ -119,7 +123,6 @@ module.exports = Compiler = (function() {
             } else {
 
                 if ( atom.config.get('sass-compiler.successMsg') ) {
-
                     atom.notifications.addSuccess( 'Successfuly compiled' );
                 }
             }

--- a/lib/sass-compiler.coffee
+++ b/lib/sass-compiler.coffee
@@ -11,7 +11,7 @@ module.exports = SassCompiler =
 
         outputPath:
             title: 'Output path'
-            description: 'This specifies where the CSS will be saved. ( Path relative to your project ).'
+            description: 'Specifies where the CSS will be saved. ( Path relative to your project ).'
             type: 'string'
             default: './css/'
 
@@ -29,14 +29,14 @@ module.exports = SassCompiler =
             enum: [ 'nested', 'compressed' ]
 
         successMsg:
-            title: 'Eneable/disable success message.'
-            description: 'Turns on/off information about successfull compiling.'
+            title: 'Enable/disable success message.'
+            description: 'Turns on/off information about successful compiling.'
             type: 'boolean'
             default: true
 
         extractPath:
             title: 'Get path from file.'
-            description: 'Eneable/disable ( package tries to extract current path based on editable file and sets reference point ).'
+            description: 'Enable/disable ( package tries to extract current path based on editable file and sets reference point ).'
             type: 'boolean'
             default: false
 
@@ -52,6 +52,11 @@ module.exports = SassCompiler =
             type: 'string'
             default: '../css'
 
+        sourceMap:
+            title: 'Generate source map.'
+            description: 'Enable/disable auto-generated source map (generated.css.map).'
+            type: 'boolean'
+            default: false
 
     activate: (state) ->
         @compiler = new Compiler()

--- a/lib/sass-compiler.coffee
+++ b/lib/sass-compiler.coffee
@@ -3,23 +3,17 @@ Compiler = require './compiler'
 module.exports = SassCompiler =
 
     config:
-        inputPath:
-            title: 'Input path'
-            description: 'Specifies where the Scss files are stored. ( Path relative to your project ).'
+        inputFilePath:
+            title: 'Input File Path'
+            description: 'Where the scss file is exemple: "./frontend/app/css/main.scss"'
             type: 'string'
-            default: './css/sass/'
+            default: ''
 
-        outputPath:
-            title: 'Output path'
-            description: 'Specifies where the CSS will be saved. ( Path relative to your project ).'
+        outputFilePath:
+            title: 'Output File Path'
+            description: 'Where you want your css file is generated: "./frontend/app/css/main.css"'
             type: 'string'
-            default: './css/'
-
-        fileName:
-            title: 'File name'
-            description: 'Scss type file name, to be parent of all @include.'
-            type: 'string'
-            default: 'main'
+            default: ''
 
         outputStyle:
             title: 'Output style'
@@ -33,24 +27,6 @@ module.exports = SassCompiler =
             description: 'Turns on/off information about successful compiling.'
             type: 'boolean'
             default: true
-
-        extractPath:
-            title: 'Get path from file.'
-            description: 'Enable/disable ( package tries to extract current path based on editable file and sets reference point ).'
-            type: 'boolean'
-            default: false
-
-        inputPathExtracted:
-            title: 'Catalog where scss are stored.'
-            description: 'Specifies where your Scss files are stored. ( Relative to extracted reference point ).'
-            type: 'string'
-            default: 'sass'
-
-        outputPathExtracted:
-            title: 'Catalog for saving compiled css.'
-            description: 'Specifies where the CSS will be saved. ( Relative to extracted reference point ).'
-            type: 'string'
-            default: '../css'
 
         sourceMap:
             title: 'Generate source map.'

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sass-compiler",
   "main": "./lib/sass-compiler",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Sass Compiler based on node-sass library that provides binding for Node.js to libsass. Works only with scss syntax. ",
   "repository": "https://github.com/GomatoX/sass-compiler",
   "license": "MIT",


### PR DESCRIPTION
I wanted to have source map auto generated and figured it would be simple to add.

Also fixed problem with `project_path`, some spelling mistakes and linter errors.

The new checkbox:
![new-sourcemap-checkbox](https://cloud.githubusercontent.com/assets/3286135/12895447/77bd6aea-ce6a-11e5-9526-8fa6bd2549c7.jpg)
